### PR TITLE
[1.21] Compatiblity for shears of other mods

### DIFF
--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/acacia_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/acacia_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/alpha_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/alpha_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/apple_oak_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/apple_oak_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {
@@ -142,7 +142,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/ashen_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/ashen_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/ashen_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/ashen_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {
@@ -142,7 +142,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/bamboo_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/bamboo_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/baobab_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/baobab_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/baobab_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/baobab_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/birch_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/birch_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/blackwood_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/blackwood_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/blackwood_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/blackwood_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/bladed_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/bladed_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/bladed_tall_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/bladed_tall_grass.json
@@ -34,7 +34,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -98,7 +98,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/blue_magnolia_flowers.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/blue_magnolia_flowers.json
@@ -10,7 +10,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "items": "minecraft:shears"
+                "items": "#c:tools/shear"
               }
             }
           ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/blue_magnolia_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/blue_magnolia_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/brimwood_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/brimwood_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/cherry_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/cherry_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/cobalt_webbing.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/cobalt_webbing.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/cypress_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/cypress_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/cypress_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/cypress_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dark_oak_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dark_oak_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dead_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dead_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dead_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dead_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dead_pine_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dead_pine_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dropleaf.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dropleaf.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dropleaf_plant.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/dropleaf_plant.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/enchanted_birch_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/enchanted_birch_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/eucalyptus_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/eucalyptus_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/eucalyptus_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/eucalyptus_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/flowering_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/flowering_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {
@@ -142,7 +142,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/frozen_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/frozen_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/glistering_ivy.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/glistering_ivy.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/glistering_ivy_plant.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/glistering_ivy_plant.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/golden_larch_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/golden_larch_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/hanging_earlight.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/hanging_earlight.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/hanging_earlight_plant.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/hanging_earlight_plant.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/hyacinth_flowers.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/hyacinth_flowers.json
@@ -10,7 +10,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "items": "minecraft:shears"
+                "items": "#c:tools/shear"
               }
             }
           ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/joshua_beard.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/joshua_beard.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/joshua_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/joshua_leaves.json
@@ -34,7 +34,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -104,7 +104,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/jungle_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/jungle_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/kapok_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/kapok_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/kapok_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/kapok_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/kapok_vines.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/kapok_vines.json
@@ -7,7 +7,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": "minecraft:shears"
+            "items": "#c:tools/shear"
           }
         }
       ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/kapok_vines_plant.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/kapok_vines_plant.json
@@ -7,7 +7,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": "minecraft:shears"
+            "items": "#c:tools/shear"
           }
         }
       ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/larch_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/larch_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/larch_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/larch_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/magnolia_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/magnolia_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/magnolia_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/magnolia_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/mangrove_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/mangrove_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/maple_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/maple_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/maple_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {
@@ -142,7 +142,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/mauve_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/mauve_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/mauve_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/mauve_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {
@@ -142,7 +142,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/medium_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/medium_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/oak_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/oak_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/orange_maple_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/orange_maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {
@@ -142,7 +142,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/palm_beard.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/palm_beard.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/palm_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/palm_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/pine_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/pine_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/pine_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/pine_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/pink_magnolia_flowers.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/pink_magnolia_flowers.json
@@ -10,7 +10,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "items": "minecraft:shears"
+                "items": "#c:tools/shear"
               }
             }
           ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/pink_magnolia_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/pink_magnolia_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/prismoss_sprout.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/prismoss_sprout.json
@@ -7,7 +7,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": "minecraft:shears"
+            "items": "#c:tools/shear"
           }
         }
       ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/red_maple_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/red_maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {
@@ -142,7 +142,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/redwood_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/redwood_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/redwood_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/redwood_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/sandy_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/sandy_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/sandy_tall_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/sandy_tall_grass.json
@@ -34,7 +34,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -98,7 +98,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/silver_birch_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/silver_birch_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/silver_birch_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/silver_birch_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/small_desert_shrub.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/small_desert_shrub.json
@@ -7,7 +7,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": "minecraft:shears"
+            "items": "#c:tools/shear"
           }
         }
       ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/small_oak_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/small_oak_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {
@@ -142,7 +142,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/socotra_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/socotra_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/socotra_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/socotra_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/spanish_moss.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/spanish_moss.json
@@ -7,7 +7,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": "minecraft:shears"
+            "items": "#c:tools/shear"
           }
         }
       ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/spanish_moss_plant.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/spanish_moss_plant.json
@@ -7,7 +7,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": "minecraft:shears"
+            "items": "#c:tools/shear"
           }
         }
       ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/spruce_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/spruce_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/steppe_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/steppe_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/steppe_shrub.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/steppe_shrub.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/steppe_tall_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/steppe_tall_grass.json
@@ -34,7 +34,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -98,7 +98,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/stone_bud.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/stone_bud.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/white_magnolia_flowers.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/white_magnolia_flowers.json
@@ -10,7 +10,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "items": "minecraft:shears"
+                "items": "#c:tools/shear"
               }
             }
           ],

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/white_magnolia_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/white_magnolia_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/willow_branch.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/willow_branch.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -41,7 +41,7 @@
           "term": {
             "condition": "minecraft:match_tool",
             "predicate": {
-              "items": "minecraft:shears"
+              "items": "#c:tools/shear"
             }
           }
         }

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/willow_leaves.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/willow_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": "minecraft:shears"
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
@@ -74,7 +74,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": "minecraft:shears"
+                  "items": "#c:tools/shear"
                 }
               },
               {

--- a/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/windswept_grass.json
+++ b/common/src/generated/resources/data/regions_unexplored/loot_table/blocks/windswept_grass.json
@@ -34,7 +34,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],
@@ -98,7 +98,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": "minecraft:shears"
+                    "items": "#c:tools/shear"
                   }
                 }
               ],

--- a/neoforge/src/main/java/net/regions_unexplored/datagen/RuBlockLootTables.java
+++ b/neoforge/src/main/java/net/regions_unexplored/datagen/RuBlockLootTables.java
@@ -1,14 +1,17 @@
 package net.regions_unexplored.datagen;
 
 import net.minecraft.advancements.critereon.BlockPredicate;
+import net.minecraft.advancements.critereon.ItemPredicate;
 import net.minecraft.advancements.critereon.LocationPredicate;
 import net.minecraft.advancements.critereon.StatePropertiesPredicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.loot.BlockLootSubProvider;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
@@ -21,23 +24,25 @@ import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
 import net.minecraft.world.level.storage.loot.entries.LootPoolEntryContainer;
+import net.minecraft.world.level.storage.loot.entries.LootPoolSingletonContainer;
 import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
 import net.minecraft.world.level.storage.loot.functions.LimitCount;
 import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
 import net.minecraft.world.level.storage.loot.predicates.*;
 import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
 import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
+import net.neoforged.neoforge.common.Tags;
 import net.regions_unexplored.Constants;
 import net.regions_unexplored.block.RuBlocks;
 import net.regions_unexplored.item.RuItems;
 import net.regions_unexplored.world.level.block.plant.food.SalmonBerryBushBlock;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class RuBlockLootTables extends BlockLootSubProvider {
 
+    protected static final LootItemCondition.Builder HAS_SHEARS = MatchTool.toolMatches(ItemPredicate.Builder.item().of(Tags.Items.TOOLS_SHEAR));
     private final LootItemCondition.Builder HAS_SHEARS_OR_SILK_TOUCH = HAS_SHEARS.or(this.hasSilkTouch());
     private final LootItemCondition.Builder HAS_NO_SHEARS_OR_SILK_TOUCH = HAS_SHEARS_OR_SILK_TOUCH.invert();
 
@@ -47,6 +52,8 @@ public class RuBlockLootTables extends BlockLootSubProvider {
     protected static final float[] JOSHUA_LEAVES_SAPLING_CHANCES = new float[]{0.13F, 0.15F, 0.17F, 0.185F};
     protected static final float[] PALM_LEAVES_SAPLING_CHANCES = new float[]{0.1F, 0.125F, 0.14F, 0.155F};
     protected static final float[] SMALL_OAK_LEAVES_SAPLING_CHANCES = new float[]{0.075F, 0.08F, 0.089F, 0.1275F};
+
+    private static final float[] NORMAL_LEAVES_STICK_CHANCES = new float[]{0.02F, 0.022222223F, 0.025F, 0.033333335F, 0.1F};
 
     public RuBlockLootTables(HolderLookup.Provider holder) {
         super(Set.of(), FeatureFlags.REGISTRY.allFlags(), holder);
@@ -979,6 +986,7 @@ public class RuBlockLootTables extends BlockLootSubProvider {
         return BuiltInRegistries.BLOCK.entrySet().stream().filter(entry -> entry.getKey().location().getNamespace().contains(Constants.MOD_ID)).map(Map.Entry::getValue).toList();
     }
 
+    @Override
     protected LootTable.Builder createMushroomBlockDrop(Block block, ItemLike item) {
         return createSilkTouchDispatchTable(block, this.applyExplosionDecay(block, LootItem.lootTableItem(item).apply(SetItemCountFunction.setCount(UniformGenerator.between(0.0F, 2.0F))).apply(LimitCount.limitCount(IntRange.lowerBound(0)))));
     }
@@ -991,5 +999,37 @@ public class RuBlockLootTables extends BlockLootSubProvider {
     protected LootTable.Builder createDoublePlantWithSeedDropsNoGrass(Block block) {
         LootPoolEntryContainer.Builder<?> builder = LootItem.lootTableItem(block).apply(SetItemCountFunction.setCount(ConstantValue.exactly(2.0F))).when(HAS_SHEARS).otherwise(this.applyExplosionCondition(block, LootItem.lootTableItem(Items.WHEAT_SEEDS)).when(LootItemRandomChanceCondition.randomChance(0.125F)));
         return LootTable.lootTable().withPool(LootPool.lootPool().add(builder).when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(block).setProperties(StatePropertiesPredicate.Builder.properties().hasProperty(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER))).when(LocationCheck.checkLocation(LocationPredicate.Builder.location().setBlock(BlockPredicate.Builder.block().of(block).setProperties(StatePropertiesPredicate.Builder.properties().hasProperty(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER))), new BlockPos(0, 1, 0)))).withPool(LootPool.lootPool().add(builder).when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(block).setProperties(StatePropertiesPredicate.Builder.properties().hasProperty(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER))).when(LocationCheck.checkLocation(LocationPredicate.Builder.location().setBlock(BlockPredicate.Builder.block().of(block).setProperties(StatePropertiesPredicate.Builder.properties().hasProperty(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER))), new BlockPos(0, -1, 0))));
+    }
+
+    @Override
+    protected LootTable.Builder createShearsDispatchTable(Block block, LootPoolEntryContainer.Builder<?> builder) {
+        return createSelfDropDispatchTable(block, HAS_SHEARS, builder);
+    }
+
+    protected static LootTable.Builder createShearsOnlyDrop(ItemLike item) {
+        return LootTable.lootTable().withPool(LootPool.lootPool().setRolls(ConstantValue.exactly(1.0F)).when(HAS_SHEARS).add(LootItem.lootTableItem(item)));
+    }
+
+    @Override
+    protected LootTable.Builder createSilkTouchOrShearsDispatchTable(Block block, LootPoolEntryContainer.Builder<?> builder) {
+        return createSelfDropDispatchTable(block, HAS_SHEARS_OR_SILK_TOUCH, builder);
+    }
+
+    @Override
+    protected LootTable.Builder createLeavesDrops(Block block, Block block1, float... chances) {
+        HolderLookup.RegistryLookup<Enchantment> registrylookup = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
+        return this.createSilkTouchOrShearsDispatchTable(block, ((LootPoolSingletonContainer.Builder)this.applyExplosionCondition(block, LootItem.lootTableItem(block1))).when(BonusLevelTableCondition.bonusLevelFlatChance(registrylookup.getOrThrow(Enchantments.FORTUNE), chances))).withPool(LootPool.lootPool().setRolls(ConstantValue.exactly(1.0F)).when(HAS_NO_SHEARS_OR_SILK_TOUCH).add(((LootPoolSingletonContainer.Builder)this.applyExplosionDecay(block, LootItem.lootTableItem(Items.STICK).apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 2.0F))))).when(BonusLevelTableCondition.bonusLevelFlatChance(registrylookup.getOrThrow(Enchantments.FORTUNE), NORMAL_LEAVES_STICK_CHANCES))));
+    }
+
+    @Override
+    protected LootTable.Builder createOakLeavesDrops(Block block, Block block1, float... chances) {
+        HolderLookup.RegistryLookup<Enchantment> registrylookup = this.registries.lookupOrThrow(Registries.ENCHANTMENT);
+        return this.createLeavesDrops(block, block1, chances).withPool(LootPool.lootPool().setRolls(ConstantValue.exactly(1.0F)).when(HAS_NO_SHEARS_OR_SILK_TOUCH).add(((LootPoolSingletonContainer.Builder)this.applyExplosionCondition(block, LootItem.lootTableItem(Items.APPLE))).when(BonusLevelTableCondition.bonusLevelFlatChance(registrylookup.getOrThrow(Enchantments.FORTUNE), new float[]{0.005F, 0.0055555557F, 0.00625F, 0.008333334F, 0.025F}))));
+    }
+
+    @Override
+    protected LootTable.Builder createDoublePlantWithSeedDrops(Block block, Block block1) {
+        LootPoolEntryContainer.Builder<?> builder = ((LootPoolSingletonContainer.Builder)LootItem.lootTableItem(block1).apply(SetItemCountFunction.setCount(ConstantValue.exactly(2.0F))).when(HAS_SHEARS)).otherwise(((LootPoolSingletonContainer.Builder)this.applyExplosionCondition(block, LootItem.lootTableItem(Items.WHEAT_SEEDS))).when(LootItemRandomChanceCondition.randomChance(0.125F)));
+        return LootTable.lootTable().withPool(LootPool.lootPool().add(builder).when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(block).setProperties(net.minecraft.advancements.critereon.StatePropertiesPredicate.Builder.properties().hasProperty(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER))).when(LocationCheck.checkLocation(net.minecraft.advancements.critereon.LocationPredicate.Builder.location().setBlock(net.minecraft.advancements.critereon.BlockPredicate.Builder.block().of(new Block[]{block}).setProperties(net.minecraft.advancements.critereon.StatePropertiesPredicate.Builder.properties().hasProperty(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER))), new BlockPos(0, 1, 0)))).withPool(LootPool.lootPool().add(builder).when(LootItemBlockStatePropertyCondition.hasBlockStateProperties(block).setProperties(net.minecraft.advancements.critereon.StatePropertiesPredicate.Builder.properties().hasProperty(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER))).when(LocationCheck.checkLocation(net.minecraft.advancements.critereon.LocationPredicate.Builder.location().setBlock(net.minecraft.advancements.critereon.BlockPredicate.Builder.block().of(new Block[]{block}).setProperties(net.minecraft.advancements.critereon.StatePropertiesPredicate.Builder.properties().hasProperty(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER))), new BlockPos(0, -1, 0))));
     }
 }


### PR DESCRIPTION
Hello,

I am the developer of the mods Ceramic Shears and Wooden Shears. A user has issues when using my shears on the leaves of your mod: https://github.com/cech12/WoodenShears/issues/19
The reason is, that your mod is not using the convential shear tag "c:tools/shear" of Fabric and NeoForge to support shears of other mods.
- https://github.com/FabricMC/fabric/tree/1.21/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/tools (hint: "c:tools/shears" is deprecated)
- https://github.com/neoforged/NeoForge/tree/1.21.x/src/generated/resources/data/c/tags/item/tools

This PR adds the conventional tag "c:tools/shear" to your datagen.
